### PR TITLE
add optional value for AndroidChannelid

### DIFF
--- a/src/OneSignal.CSharp.SDK.NetStandard/Resources/Notifications/NotificationCreateOptions.cs
+++ b/src/OneSignal.CSharp.SDK.NetStandard/Resources/Notifications/NotificationCreateOptions.cs
@@ -142,7 +142,7 @@ namespace OneSignal.CSharp.SDK.NetStandard.Resources.Notifications
         /// Android ChannelId
         /// </summary>
         [JsonProperty("android_channel_id")]
-        public Guid AndroidChannelId { get; set; }
+        public Guid? AndroidChannelId { get; set; }
 
         /// <summary><br/>
         /// Picture to display in the expanded view. Can be a drawable resource name or a URL.<br/>


### PR DESCRIPTION
O campo android_channel_id é opcional na API. If it is not a credit, a default value will be assigned, according to the documents.
The field android_channel_id is optional in the API. 

The field was sent a guid empty 00000-0000

https://documentation.onesignal.com/docs/android-notification-categories